### PR TITLE
New afternoon plan

### DIFF
--- a/py/surveysim/surveysim.py
+++ b/py/surveysim/surveysim.py
@@ -33,6 +33,7 @@ def surveySim(sd0, ed0, seed=None, tilesubset=None, use_jpl=False):
     enddate = datetime(endyear, endmonth, endday, 19, 0, 0)
 
     sp = surveyPlan(tilesubset=tilesubset)
+    tiles_todo = sp.numtiles
     day0 = Time(datetime(startyear, startmonth, startday, 19, 0, 0))
     mjd_start = day0.mjd
     w = weatherModule(startdate, seed)
@@ -63,13 +64,14 @@ def surveySim(sd0, ed0, seed=None, tilesubset=None, use_jpl=False):
             ntodate = len(tilesObserved)
             if day_stats['MoonFrac'] < 0.85:
                 w.resetDome(day)
-                tiles_todo, obsplan = sp.afternoonPlan(day_stats, tilesObserved)
+                obsplan = sp.afternoonPlan(day_stats, tilesObserved)
                 tilesObserved = nightOps(day_stats, obsplan, w, ocnt, tilesObserved, use_jpl=use_jpl)
                 t = Time(day, format = 'datetime')
                 ntiles_tonight = len(tilesObserved)-ntodate
+                tiles_todo -= ntiles_tonight
                 print ('On the night starting ', t.iso, ', we observed ', ntiles_tonight, ' tiles.')
-                print ('There are ', tiles_todo-ntiles_tonight, 'left to observe.')
-                if (tiles_todo-ntiles_tonight) == 0:
+                print ('There are ', tiles_todo, 'left to observe.')
+                if (sp.numtiles - len(tilesObserved)) == 0:
                     survey_done = True
             else:
                 print ('Monthly maintenance period around Full Moon. No observing.')

--- a/py/surveysim/weather.py
+++ b/py/surveysim/weather.py
@@ -62,8 +62,8 @@ class weatherModule:
             seeing: float (arcseconds)
         """
         seeing = self.rn.lognormal(0.0, 0.25)
-        if seeing < 0.5:
-            seeing = 0.5
+        if seeing < 0.65:
+            seeing = 0.65
         return seeing
 
     def simTransparency(self, dt):


### PR DESCRIPTION
Includes minor changes to accommodate the new afternoon planner and other small modifications

In surveysim.py:
 - Calculates the calendar of the Sun, Moon and twilight for the entire survey right away, rather than day by day.  This is needed by the HA assignment code.
 - Changed the way the number of remaining tiles is computed.

In weather.py:
 - Changed the minimum value of the seeing from 0.5" to 0.65"
