### PR TITLE
desisurvey.nightcal -> desisurvey.ephemerides

### DIFF
--- a/py/surveysim/nightops.py
+++ b/py/surveysim/nightops.py
@@ -12,7 +12,7 @@ from desisurvey.exposurecalc import expTimeEstimator, airMassCalculator
 from desisurvey.utils import mjd2lst
 from desisurvey.nextobservation import nextFieldSelector
 from surveysim.observefield import observeField
-import desisurvey.nightcal
+import desisurvey.ephemerides
 import desiutil.log
 
 
@@ -90,7 +90,7 @@ def nightOps(day_stats, date_string, obsplan, w, ocnt, tilesObserved,
 
         # Initialize a moon (alt, az) interpolator using the pre-tabulated
         # ephemerides for this night.
-        moon_pos = desisurvey.nightcal.get_moon_interpolator(day_stats)
+        moon_pos = desisurvey.ephemerides.get_moon_interpolator(day_stats)
 
         slew = False
         ra_prev = 1.0e99

--- a/py/surveysim/simulator.py
+++ b/py/surveysim/simulator.py
@@ -11,7 +11,7 @@ import astropy.io.fits as pyfits
 import astropy.units as u
 import astropy.time
 from surveysim.weather import weatherModule
-from desisurvey.nightcal import Ephemerides
+from desisurvey.ephemerides import Ephemerides
 from desisurvey.afternoonplan import surveyPlan
 from surveysim.nightops import obsCount, nightOps
 import desiutil.log


### PR DESCRIPTION
desihub/desisurvey#30 removed `desisurvey.nightcal` and split up its functionality into several other locations including `desisurvey.ephemerides`.  We missed getting `surveysim` in sync and it was still referencing `desisurvey.nightcal.Ephemerides` and `desisurvey.nightcal.get_moon_interpolator`.

This PR fixes that so that surveysim master will work with desisurvey master.