### PR TITLE
swap arc/flat calib exposure order

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ surveysim change log
 0.9.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Do arc exposures before flat exposures (PR `#57`_).
+
+.. _`#57`: https://github.com/desihub/surveysim/pull/57
 
 0.9.0 (2017-11-09)
 ------------------

--- a/py/surveysim/util.py
+++ b/py/surveysim/util.py
@@ -53,7 +53,7 @@ def add_calibration_exposures(exposures, flats_per_night=3, arcs_per_night=3,
     current_night = '19730703'
     expid = 0
     calib_time = lambda x: exptime[x] + readout
-    calib_sequence = (['flat']*flats_per_night + ['arc']*arcs_per_night +
+    calib_sequence = (['arc']*arcs_per_night + ['flat']*flats_per_night +
                       ['dark']*darks_per_night + ['zero']*zeroes_per_night)
     calib_times = np.cumsum(np.array([calib_time(c)
                                       for c in calib_sequence]))[::-1]


### PR DESCRIPTION
This PR swaps the order of the arcs vs. flats.  Arcs first (to measure PSF), then flats (which needs the PSFs for their extractions).