### PR TITLE
update travis test versions; drop py2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,9 @@ env:
         # to repeat them for all configurations.
         # - NUMPY_VERSION=1.10
         # - SCIPY_VERSION=0.16
-        - ASTROPY_VERSION=1.3.3
+        - ASTROPY_VERSION=2.0.4
         - SPHINX_VERSION=1.5
-        - DESIUTIL_VERSION=1.9.6
+        - DESIUTIL_VERSION=1.9.9
         # - SPECLITE_VERSION=0.5
         - SPECSIM_VERSION=v0.9
         # - SPECTER_VERSION=0.6.0
@@ -80,7 +80,7 @@ env:
         # Debug the Travis install process.
         - DEBUG=False
     matrix:
-        - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
+        # - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
 
 matrix:
@@ -112,10 +112,10 @@ matrix:
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
 
         # Default versions
-        - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='test'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
+        # - os: linux
+        #   env: PYTHON_VERSION=2.7 SETUP_CMD='test'
+        #        CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+        #        PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
 
         # More recent versions
         # We're already on the "more recent" versions.


### PR DESCRIPTION
Travis tests on master are failing due to a pretty basic import error:
```
Collecting desiutil from git+https://github.com/desihub/desiutil.git@1.9.6#egg=desiutil
  Cloning https://github.com/desihub/desiutil.git (to revision 1.9.6) to /tmp/pip-install-4r7ew626/desiutil
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-4r7ew626/desiutil/setup.py", line 19, in <module>
        from desiutil.setup import DesiModule, DesiTest, DesiVersion, get_version
      File "/tmp/pip-install-4r7ew626/desiutil/py/desiutil/setup.py", line 23, in <module>
        from setuptools.py31compat import unittest_main
    ImportError: cannot import name 'unittest_main'
```
This updates the travis version to desiutil 1.9.9 which I think fixes this.  It also updates astropy 2.0.4 and drops py2.7 support.