### PR TITLE
add skylevel to next_tile call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ env:
         # - SPECTER_VERSION=0.6.0
         - DESIMODEL_VERSION=0.9.8
         - DESIMODEL_DATA=branches/test-0.9.8
-        - DESISURVEY_VERSION=0.11.0
+        - DESISURVEY_VERSION=master
         # - HARP_VERSION=1.0.1
         # - SPECEX_VERSION=0.3.9
         - MAIN_CMD='python setup.py'

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,8 @@ surveysim change log
 0.10.2 (unreleased)
 -------------------
 
-* No changes yet.
+* Pass dummy sky level to desisurvey scheduler.next_tile; needed to match
+  API change in desisurvey PR #99.
 
 0.10.1 (2018-12-16)
 -------------------

--- a/py/surveysim/nightops.py
+++ b/py/surveysim/nightops.py
@@ -97,6 +97,7 @@ def simulate_night(night, scheduler, stats, explist, weather,
     dome_is_open = False
     mjd_now = weather_mjd[0]
     completed_last = scheduler.completed_by_pass.copy()
+    sky_now = 1.0  # placeholder
     while mjd_now < end:
         if not dome_is_open:
             # Advance to the next dome opening, if any.
@@ -130,7 +131,7 @@ def simulate_night(night, scheduler, stats, explist, weather,
         seeing_now, transp_now = get_weather(mjd_now)
         # Get the next tile to observe from the scheduler.
         tileid, passnum, snr2frac_start, exposure_factor, airmass, sched_program, mjd_program_end = \
-            scheduler.next_tile(mjd_now, ETC, seeing_now, transp_now)
+            scheduler.next_tile(mjd_now, ETC, seeing_now, transp_now, sky_now)
         if tileid is None:
             # Deadtime while we delay and try again.
             mjd_now += NO_TILE_AVAIL_DELAY


### PR DESCRIPTION
This PR adds a dummy sky level to the call to desisurvey scheduler.next_tile(), due to the API change introduced in desihub/desisurvey#99.

This is still a dummy value on the surveysim side, and unused on the desisurvey side, so this PR is only restoring the ability of the master version of both of these to work together; it isn't trying to address the underlying issue of how the sky should be used.