### PR TITLE
travis testing in prep for 0.11.0 tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ env:
         # - SPECTER_VERSION=0.6.0
         - DESIMODEL_VERSION=0.9.8
         - DESIMODEL_DATA=branches/test-0.9.8
-        - DESISURVEY_VERSION=master
+        - DESISURVEY_VERSION=0.12.0
         # - HARP_VERSION=1.0.1
         # - SPECEX_VERSION=0.3.9
         - MAIN_CMD='python setup.py'

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,11 +2,19 @@
 surveysim change log
 ====================
 
-0.10.2 (unreleased)
+0.11.1 (unreleased)
+-------------------
+
+* No changes yet.
+
+0.11.0 (2019-08-09)
 -------------------
 
 * Pass dummy sky level to desisurvey scheduler.next_tile; needed to match
-  API change in desisurvey PR #99.
+  API change in desisurvey PR #99. (surveysim PR `#64`_).
+  Requires desisurvey 0.12.0 or later.
+
+.. _`#64`: https://github.com/desihub/surveysim/pull/64
 
 0.10.1 (2018-12-16)
 -------------------


### PR DESCRIPTION
Updated travis testing to use new desisurvey tag 0.12.0.  Going via PR to make sure that works before tagging surveysim/0.11.0.