### PR TITLE
Make exposure_factor conditions consistent with etc.start conditions

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,8 @@ surveysim change log
 0.12.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Use consistent conditions in scheduler.next_tile and in ETC.start
+  (PR `#75`_)
 
 0.12.0 (2020-08-03)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,6 +8,8 @@ surveysim change log
 * Use consistent conditions in scheduler.next_tile and in ETC.start
   (PR `#75`_)
 
+.. _`#75`: https://github.com/desihub/surveysim/pull/75
+
 0.12.0 (2020-08-03)
 -------------------
 

--- a/py/surveysim/exposures.py
+++ b/py/surveysim/exposures.py
@@ -35,6 +35,7 @@ class ExposureList(object):
             ('EXPTIME', np.float32),
             ('TILEID', np.int32),
             ('SNR2FRAC', np.float32),
+            ('DSNR2FRAC', np.float32),
             ('AIRMASS', np.float32),
             ('SEEING', np.float32),
             ('TRANSP', np.float32),
@@ -94,7 +95,7 @@ class ExposureList(object):
         self._tiledata['AVAIL'][available] = night_index
         self._tiledata['PLANNED'][planned] = night_index
 
-    def add(self, mjd, exptime, tileID, snr2frac, airmass, seeing, transp, sky):
+    def add(self, mjd, exptime, tileID, snr2frac, dsnr2frac, airmass, seeing, transp, sky):
         """Record metadata for a single exposure.
 
         Parameters
@@ -104,6 +105,8 @@ class ExposureList(object):
         tileID : int
             ID of the observed tile.
         snr2frac : float
+            Fractional SNR2 accumulated on this tile at the end of exposure.
+        dsnr2frac : float
             Fractional SNR2 accumulated on this tile during this exposure.
         airmass : float
             Average airmass during this exposure.
@@ -118,8 +121,8 @@ class ExposureList(object):
             raise RuntimeError(
                 'Need to increase max_nexp={}'.format(len(self._exposures)))
         self._exposures[self.nexp] = (
-            self.nexp, mjd, exptime, tileID, snr2frac, airmass, seeing,
-            transp, sky)
+            self.nexp, mjd, exptime, tileID, snr2frac, dsnr2frac,
+            airmass, seeing, transp, sky)
         self.nexp += 1
         tileinfo = self._tiledata[self.tiles.index(tileID)]
         tileinfo['EXPTIME'] += exptime

--- a/py/surveysim/exposures.py
+++ b/py/surveysim/exposures.py
@@ -30,7 +30,7 @@ class ExposureList(object):
     def __init__(self, restore=None, max_nexp=60000):
         self.tiles = desisurvey.tiles.get_tiles()
         self._exposures = np.empty(max_nexp, dtype=[
-            ('EXPID', np.float64),
+            ('EXPID', np.int32),
             ('MJD', np.float64),
             ('EXPTIME', np.float32),
             ('TILEID', np.int32),

--- a/py/surveysim/nightops.py
+++ b/py/surveysim/nightops.py
@@ -123,15 +123,15 @@ def simulate_night(night, scheduler, stats, explist, weather,
             dome_is_open = True
             weather_idx = idx_open
 
-        # == NEXT TILE ===========================================================        
+        # == NEXT TILE ===========================================================
         # Dome is open from mjd_now to next_dome_closing.
         mjd_last = mjd_now
         tdead = 0.
         # Get the current observing conditions.
-        seeing_now, transp_now = get_weather(mjd_now)
+        seeing_tile, transp_tile = get_weather(mjd_now)
         # Get the next tile to observe from the scheduler.
         tileid, passnum, snr2frac_start, exposure_factor, airmass, sched_program, mjd_program_end = \
-            scheduler.next_tile(mjd_now, ETC, seeing_now, transp_now, sky_now)
+            scheduler.next_tile(mjd_now, ETC, seeing_tile, transp_tile, sky_now)
         if tileid is None:
             # Deadtime while we delay and try again.
             mjd_now += NO_TILE_AVAIL_DELAY
@@ -155,7 +155,7 @@ def simulate_night(night, scheduler, stats, explist, weather,
             # Charge this as setup time whether or not it was aborted.
             nightstats['tsetup'][passnum] += mjd_now - mjd_last
 
-            if dome_is_open:            
+            if dome_is_open:
                 # Lookup the program of the next tile, which might be
                 # different from the scheduled program in ``sched_program``.
                 tile_program = scheduler.tiles.pass_program[passnum]
@@ -169,7 +169,7 @@ def simulate_night(night, scheduler, stats, explist, weather,
                     # Use the ETC to control the shutter.
                     mjd_open_shutter = mjd_now
                     ETC.start(mjd_now, tileid, tile_program, snr2frac_start, exposure_factor,
-                              seeing_now, transp_now, sky_now)
+                              seeing_tile, transp_tile, sky_now)
                     integrating = True
                     while integrating:
                         mjd_now += update_interval_days

--- a/py/surveysim/test/test_exposures.py
+++ b/py/surveysim/test/test_exposures.py
@@ -22,7 +22,7 @@ class TestExposures(Tester):
         # Accumulate some exposures
         now = 0.
         for tileID in tiles.tileID[:100]:
-            exp.add(now, gen.uniform(), tileID, *gen.uniform(size=5))
+            exp.add(now, gen.uniform(), tileID, *gen.uniform(size=6))
         # Save and restore
         exp.save('exposures_test.fits', comment='unit test')
         exp2 = ExposureList(restore='exposures_test.fits')

--- a/py/surveysim/test/test_util.py
+++ b/py/surveysim/test/test_util.py
@@ -25,8 +25,8 @@ class TestUtil(Tester):
         tileID = tiles.tileID[0]
         # List some science exposures.
         exposures = surveysim.exposures.ExposureList()
-        exposures.add(58849., 1., tileID, 1., 1., 1.1, 0.9, 1.0)
-        exposures.add(58850., 1., tileID, 1., 1., 1.1, 0.9, 1.0)
+        exposures.add(58849., 1., tileID, 1., 1., 1., 1.1, 0.9, 1.0)
+        exposures.add(58850., 1., tileID, 1., 1., 1., 1.1, 0.9, 1.0)
         for mode in 'obj', 'recarray', 'table':
             if mode == 'obj':
                 input = exposures
@@ -46,8 +46,8 @@ class TestUtil(Tester):
 
         # List some out-of-order science exposures.
         bad_exposures = surveysim.exposures.ExposureList()
-        bad_exposures.add(58851., 1., tileID, 1., 1., 1.1, 0.9, 1.0)
-        bad_exposures.add(58850., 1., tileID, 1., 1., 1.1, 0.9, 1.0)
+        bad_exposures.add(58851., 1., tileID, 1., 1., 1., 1.1, 0.9, 1.0)
+        bad_exposures.add(58850., 1., tileID, 1., 1., 1., 1.1, 0.9, 1.0)
         with self.assertRaises(ValueError):
             output = add_calibration_exposures(bad_exposures)
 


### PR DESCRIPTION
This PR addresses a small bug in the survey simulations that can lead to the ETC not correctly tracking the accumulated SNR^2.  This can actually have a modest impact on survey completion times / margins, particularly in concert with other bugs addressed in another PR on desisurvey.
https://github.com/desihub/desisurvey/pull/128

The biggest impact occurs when an exposure is started in poor conditions, but then the ETC is started in good conditions.  Then we end up integrating much longer than we need on a tile, and falsely saying that we didn't accumulate a lot of time.