### PR TITLE
Incorporate sky into survey sims

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,10 +5,13 @@ surveysim change log
 0.12.2 (unreleased)
 -------------------
 
+* Use variable sky in surveysim, albeit presently only from ephemerides.
+  (PR `#77`_)
 * Use consistent conditions in scheduler.next_tile and in ETC.start
   (PR `#75`_)
 
 .. _`#75`: https://github.com/desihub/surveysim/pull/75
+.. _`#77`: https://github.com/desihub/surveysim/pull/76
 
 0.12.1 (2020-12-11)
 -------------------

--- a/py/surveysim/exposures.py
+++ b/py/surveysim/exposures.py
@@ -95,7 +95,8 @@ class ExposureList(object):
         self._tiledata['AVAIL'][available] = night_index
         self._tiledata['PLANNED'][planned] = night_index
 
-    def add(self, mjd, exptime, tileID, snr2frac, dsnr2frac, airmass, seeing, transp, sky):
+    def add(self, mjd, exptime, tileID, snr2frac, dsnr2frac,
+            airmass, seeing, transp, sky):
         """Record metadata for a single exposure.
 
         Parameters

--- a/py/surveysim/nightops.py
+++ b/py/surveysim/nightops.py
@@ -178,7 +178,6 @@ def simulate_night(night, scheduler, stats, explist, weather,
                     # -- NEXT EXPOSURE ---------------------------------------------------
                     # Use the ETC to control the shutter.
                     mjd_open_shutter = mjd_now
-                    seeing_now, transp_now, sky_now = get_weather(mjd_now)
                     ETC.start(mjd_now, tileid, tile_program, snr2frac_start,
                               exposure_factor,
                               seeing_tile, transp_tile, sky_tile)


### PR DESCRIPTION
This PR uses the desisurvey.etc sky functionality added in https://github.com/desihub/desisurvey/pull/129 to include the sky into the survey sims.  This presently uses the simplest possible functionality, reproducing the existing behavior where the sky just scales the exposure factors by constants that depend on the DARK/GRAY/BRIGHT ephemerides definitions.

This PR presently has no appreciable impact on margins, since the changes end up being bookkeeping, though small differences occur because the sky may change during an exposure, which formerly was not part of the model.