### PR TITLE
github tests with astropy/7.x

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -57,16 +57,16 @@ jobs:
                 python -m pip install "numpy${{ matrix.numpy-version }}" "matplotlib${{ matrix.matplotlib-version }}" "astropy${{ matrix.astropy-version }}" "specutils${{ matrix.specutils-version }}"
             - name: Install DESI packages
               env:
-                  DESIMODEL_VERSION: 0.19.3
+                  DESIMODEL_VERSION: 0.20.0
                   DESISURVEY_VERSION: update-test-matrix
               run: |
                 python -m pip install desiutil
                 python -m pip install --no-build-isolation specsim
-                python -m pip install git+https://github.com/desihub/desimodel.git@${DESIMODEL_VERSION}#egg=desimodel
+                python -m pip install desimodel==${DESIMODEL_VERSION}
                 python -m pip install git+https://github.com/desihub/desisurvey.git@${DESISURVEY_VERSION}#egg=desisurvey
             - name: Install desimodel data
               env:
-                  DESIMODEL_DATA: branches/test-0.19
+                  DESIMODEL_DATA: branches/test-0.20
               run: install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
             - name: Print Python package versions
               run: python -m pip freeze
@@ -97,16 +97,16 @@ jobs:
                 python -m pip install "numpy<1.23" "matplotlib<3.7" "astropy<6.1" "specutils<1.15"
             - name: Install DESI packages
               env:
-                  DESIMODEL_VERSION: 0.19.3
+                  DESIMODEL_VERSION: 0.20.0
                   DESISURVEY_VERSION: update-test-matrix
               run: |
                 python -m pip install desiutil
                 python -m pip install --no-build-isolation specsim
-                python -m pip install git+https://github.com/desihub/desimodel.git@${DESIMODEL_VERSION}#egg=desimodel
+                python -m pip install desimodel==${DESIMODEL_VERSION}
                 python -m pip install git+https://github.com/desihub/desisurvey.git@${DESISURVEY_VERSION}#egg=desisurvey
             - name: Install desimodel data
               env:
-                  DESIMODEL_DATA: branches/test-0.19
+                  DESIMODEL_DATA: branches/test-0.20
               run: install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
             - name: Print Python package versions
               run: python -m pip freeze

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,12 +58,12 @@ jobs:
             - name: Install DESI packages
               env:
                   DESIMODEL_VERSION: 0.20.0
-                  DESISURVEY_VERSION: update-test-matrix
+                  DESISURVEY_VERSION: main
               run: |
                 python -m pip install desiutil
                 python -m pip install --no-build-isolation specsim
                 python -m pip install desimodel==${DESIMODEL_VERSION}
-                python -m pip install git+https://github.com/desihub/desisurvey.git@${DESISURVEY_VERSION}#egg=desisurvey
+                python -m pip install git+https://github.com/desihub/desisurvey@${DESISURVEY_VERSION}
             - name: Install desimodel data
               env:
                   DESIMODEL_DATA: branches/test-0.20
@@ -98,12 +98,12 @@ jobs:
             - name: Install DESI packages
               env:
                   DESIMODEL_VERSION: 0.20.0
-                  DESISURVEY_VERSION: update-test-matrix
+                  DESISURVEY_VERSION: main
               run: |
                 python -m pip install desiutil
                 python -m pip install --no-build-isolation specsim
                 python -m pip install desimodel==${DESIMODEL_VERSION}
-                python -m pip install git+https://github.com/desihub/desisurvey.git@${DESISURVEY_VERSION}#egg=desisurvey
+                python -m pip install git+https://github.com/desihub/desisurvey@${DESISURVEY_VERSION}
             - name: Install desimodel data
               env:
                   DESIMODEL_DATA: branches/test-0.20

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,7 +21,7 @@ jobs:
                       python-version: '3.13'
                       numpy-version: '<3'
                       matplotlib-version: '<3.11'
-                      astropy-version: '<7'
+                      astropy-version: '<8'
                       specutils-version: '<3'
                     - os: ubuntu-latest
                       python-version: '3.12'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -60,7 +60,8 @@ jobs:
                   DESIMODEL_VERSION: 0.19.3
                   DESISURVEY_VERSION: update-test-matrix
               run: |
-                python -m pip install desiutil specsim
+                python -m pip install desiutil
+                python -m pip install --no-build-isolation specsim
                 python -m pip install git+https://github.com/desihub/desimodel.git@${DESIMODEL_VERSION}#egg=desimodel
                 python -m pip install git+https://github.com/desihub/desisurvey.git@${DESISURVEY_VERSION}#egg=desisurvey
             - name: Install desimodel data
@@ -99,7 +100,8 @@ jobs:
                   DESIMODEL_VERSION: 0.19.3
                   DESISURVEY_VERSION: update-test-matrix
               run: |
-                python -m pip install desiutil specsim
+                python -m pip install desiutil
+                python -m pip install --no-build-isolation specsim
                 python -m pip install git+https://github.com/desihub/desimodel.git@${DESIMODEL_VERSION}#egg=desimodel
                 python -m pip install git+https://github.com/desihub/desisurvey.git@${DESISURVEY_VERSION}#egg=desisurvey
             - name: Install desimodel data


### PR DESCRIPTION
This PR updates the GitHub actions tests to include astropy/7.x.  Side effects include updating the version of desimodel and desisurvey used in the tests due to installation compatibility issues with the latest pip/setuptools/etc.